### PR TITLE
Adds optional support for HTTPS

### DIFF
--- a/flaskext/gravatar.py
+++ b/flaskext/gravatar.py
@@ -10,7 +10,8 @@ class Gravatar(object):
                             rating='g',
                             default='retro',
                             force_default=False,
-                            force_lower=False
+                            force_lower=False,
+                            use_ssl=False
                            )
 
     :param app: Your Flask app instance
@@ -19,22 +20,23 @@ class Gravatar(object):
     :param default: Default type for unregistred emails
     :param force_default: Build only default avatars
     :param force_lower: Make email.lower() before build link
-
+    :param use_ssl: Use https rather than http
+    
     """
 
     def __init__(self, app, size=100, rating='g', default='retro',
-                 force_default=False, force_lower=False):
+                 force_default=False, force_lower=False, use_ssl=False):
 
         self.size = size
         self.rating = rating
         self.default = default
         self.force_default = force_default
+        self.use_ssl = use_ssl
 
         app.jinja_env.filters.setdefault('gravatar', self)
 
-
     def __call__(self, email, size=None, rating=None, default=None,
-                 force_default=None, force_lower=False):
+                 force_default=None, force_lower=False, use_ssl=None):
 
         """Build gravatar link."""
 
@@ -55,14 +57,21 @@ class Gravatar(object):
 
         if force_lower:
             email = email.lower()
+            
+        if use_ssl is None:
+            use_ssl = self.use_ssl
+        
+        if use_ssl:
+            url = 'https://gravatar.com/avatar/'
+        else:
+            url = 'http://gravatar.com/avatar/'
 
         hash = hashlib.md5(email).hexdigest()
 
-        link = 'http://www.gravatar.com/avatar/{hash}'\
+        link = '{url}{hash}'\
                '?s={size}&d={default}&r={rating}'.format(**locals())
 
         if force_default:
             link = link + '&f=y'
 
         return link
-


### PR DESCRIPTION
This adds a parameter to the class initialization, `use_ssl`, that defaults to `False`. If set to `True` the URL for Gravatar requests uses https rather than http.
