### PR TITLE
Update URLs of Gravatars according to current documentation

### DIFF
--- a/flaskext/gravatar.py
+++ b/flaskext/gravatar.py
@@ -31,6 +31,7 @@ class Gravatar(object):
         self.rating = rating
         self.default = default
         self.force_default = force_default
+        self.force_lower = force_lower
         self.use_ssl = use_ssl
 
         app.jinja_env.filters.setdefault('gravatar', self)


### PR DESCRIPTION
According to https://secure.gravatar.com/site/implement/images#secure-images subdomain `secure` should be used with SSL. URLs starting with `https://` and not on `secure` subdomain causes certificate alerts in my Firefox.
