### PR TITLE
Add init_app method, pass app later

### DIFF
--- a/flaskext/gravatar.py
+++ b/flaskext/gravatar.py
@@ -24,7 +24,7 @@ class Gravatar(object):
     
     """
 
-    def __init__(self, app, size=100, rating='g', default='retro',
+    def __init__(self, app=None, size=100, rating='g', default='retro',
                  force_default=False, force_lower=False, use_ssl=False, **kwargs):
 
         self.size = size


### PR DESCRIPTION
add a init_app method to the Gravatar class, so that we can make an instance without having to pass an app ( unit testing purposes, create_app factory, among other things) , and pass the app later on using init_app, like most flask extensions do

thanks.
