### PR TITLE
Use of setuptools instead of distutils.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # coding: utf8
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
         name='Flask-Gravatar',


### PR DESCRIPTION
Hi,

Thank you for the amazing work.

Here is a very dumb and simple patch to use setuptools instead of distutils.

This is especially useful when generating a Debian package (which I actually done [here](https://github.com/freelan-developers/flask-gravatar.debian) for Flask-Gravatar) because distutils doesn't deal nicely with the fact that the `__init__.py` file in `flaskext` is provided by `Flask` itself.
