### PR TITLE
docs: fix simple typo, unregistred -> unregistered

### DIFF
--- a/flask_gravatar/__init__.py
+++ b/flask_gravatar/__init__.py
@@ -82,7 +82,7 @@ class Gravatar(object):
         :param app: Your Flask app instance
         :param size: Default size for avatar
         :param rating: Default rating
-        :param default: Default type for unregistred emails
+        :param default: Default type for unregistered emails
         :param force_default: Build only default avatars
         :param force_lower: Make email.lower() before build link
         :param use_ssl: Use https rather than http


### PR DESCRIPTION
There is a small typo in flask_gravatar/__init__.py.

Should read `unregistered` rather than `unregistred`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md