### PR TITLE
update to sha256 for FIPS compliance

### DIFF
--- a/flask_gravatar/__init__.py
+++ b/flask_gravatar/__init__.py
@@ -148,7 +148,7 @@ class Gravatar(object):
             else:
                 url = 'http://www.gravatar.com/avatar/'
 
-        hash = hashlib.md5(email.encode('utf-8')).hexdigest()
+        hash = hashlib.sha256(email.encode('utf-8')).hexdigest()
 
         link = '{url}{hash}'\
                '?s={size}&d={default}&r={rating}'.format(**locals())


### PR DESCRIPTION
I confirmed that gravatar does support email encoded with sha256. Using md5 will prevent this package, and more importantly any packages that depend on it, from running on FIPS-enabled systems.